### PR TITLE
Redesign info panel to match LoveFrom overlay

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -15,6 +15,9 @@
 
   --font-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Segoe UI", Roboto, Arial, "Helvetica Neue", Helvetica, system-ui, sans-serif;
   --lh: 1.1;
+
+  --panel-duration: 1.3s;
+  --panel-delay: 0s;
 }
 
 * { box-sizing: border-box; }
@@ -48,9 +51,10 @@ body {
   text-align: center;
   line-height: var(--lh);
   font-size: clamp(28px, 11vw, 96px);
-  transition: opacity 1.2s cubic-bezier(.2,.8,.2,1),
-              transform 1.2s cubic-bezier(.2,.8,.2,1),
-              filter 1.2s cubic-bezier(.2,.8,.2,1);
+  transition:
+    opacity 1.2s cubic-bezier(.16,1,.3,1),
+    transform 1.2s cubic-bezier(.16,1,.3,1),
+    filter 1.2s cubic-bezier(.16,1,.3,1);
   will-change: opacity, transform, filter;
 }
 
@@ -85,8 +89,9 @@ body {
   width: 22px;
   height: 2px;
   background: var(--fg);
-  transition: transform 0.6s cubic-bezier(.2,.8,.2,1),
-              opacity 0.6s cubic-bezier(.2,.8,.2,1);
+  transition:
+    transform 0.6s cubic-bezier(.16,1,.3,1),
+    opacity 0.6s cubic-bezier(.16,1,.3,1);
 }
 
 /* Раскладка в состоянии "бургер" */
@@ -125,9 +130,9 @@ body {
   transform: translateY(6%);
   visibility: hidden;
   transition:
-    opacity 1.3s cubic-bezier(.2,.8,.2,1),
-    transform 1.3s cubic-bezier(.2,.8,.2,1),
-    visibility 0s linear 1.3s;
+    opacity var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
+    transform var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
+    visibility 0s linear var(--panel-duration);
   will-change: opacity, transform;
 }
 
@@ -135,7 +140,7 @@ body {
   opacity: 1;
   transform: translateY(0);
   visibility: visible;
-  transition-delay: 0s;
+  transition-delay: var(--panel-delay, 0s), var(--panel-delay, 0s), 0s;
 }
 
 .info-content {
@@ -144,6 +149,11 @@ body {
   text-align: center;
   font-family: ui-serif, "Georgia", "Times New Roman", Times, serif;
   line-height: 1.25;
+}
+
+.info-content,
+.info-content * {
+  transition: none !important;
 }
 
 .info-content .lead {
@@ -172,27 +182,6 @@ body {
 .info-content .founders i {
   font-style: italic;
 }
-
-/* Кнопка закрытия («×») — в правом верхнем углу, белая рамка */
-.info-close {
-  position: fixed;
-  top: calc(16px + var(--safe-top));
-  right: calc(16px + var(--safe-right));
-  width: 36px;
-  height: 36px;
-  line-height: 36px;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--fg);
-  border: 2px solid var(--fg);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  font-size: 24px;
-  padding: 0;
-}
-.info-close:hover { opacity: .85; }
-.info-close:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
 
 /* Уважение к reduced motion */
 @media (prefers-reduced-motion: reduce) {

--- a/assets/main.css
+++ b/assets/main.css
@@ -40,15 +40,25 @@ body {
   position: relative;
 }
 
-/* Центрированный слово-знак (без анимаций) */
+/* СЛОВО-ЗНАК: состояние по умолчанию — видно */
 .wordmark {
   margin: 0;
   font-weight: 600;
   letter-spacing: 0.02em;
   text-align: center;
   line-height: var(--lh);
-  /* Оптическая шкала размера под вьюпорт */
   font-size: clamp(28px, 11vw, 96px);
+  transition: opacity .6s cubic-bezier(.2,.8,.2,1),
+              transform .6s cubic-bezier(.2,.8,.2,1),
+              filter .6s cubic-bezier(.2,.8,.2,1);
+  will-change: opacity, transform, filter;
+}
+
+/* Когда панель открыта — «уходим в глубину» */
+.panel-open .wordmark {
+  opacity: 0.15;
+  transform: translateY(6px) scale(0.985);
+  filter: blur(0.2px);
 }
 
 /* Кнопка "i" — правый верх, внутри safe-area */
@@ -71,29 +81,30 @@ body {
 .info-btn:hover { opacity: 1; transform: scale(1.03); }
 .info-btn:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
 
-/* ПОЛНОЭКРАННАЯ СВЕТЛАЯ ПАНЕЛЬ */
+/* ИНФО-ПАНЕЛЬ: полноэкранный оверлей, тот же цвет, что и фон */
 .info-panel {
   position: fixed;
   inset: 0;
-  background: #FAFAFA;
-  color: #111;
+  background: var(--bg);
+  color: var(--fg);
   display: grid;
   place-items: center;
-  /* плавное появление */
-  opacity: 0;
-  transform: translateY(2%);
-  visibility: hidden;
-  transition:
-    opacity .35s cubic-bezier(.2,.8,.2,1),
-    transform .35s cubic-bezier(.2,.8,.2,1),
-    visibility 0s linear .35s; /* скрыть клики, когда невидима */
-  /* учёт safe-areas через внутренние паддинги контейнера */
   padding:
     calc(max(var(--padY), 24px) + var(--safe-top))
     calc(max(var(--padX), 24px) + var(--safe-right))
     calc(max(var(--padY), 24px) + var(--safe-bottom))
     calc(max(var(--padX), 24px) + var(--safe-left));
   overflow: auto;
+
+  /* старт: слегка ниже и прозрачная */
+  opacity: 0;
+  transform: translateY(6%);
+  visibility: hidden;
+  transition:
+    opacity .65s cubic-bezier(.2,.8,.2,1),
+    transform .65s cubic-bezier(.2,.8,.2,1),
+    visibility 0s linear .65s;
+  will-change: opacity, transform;
 }
 
 .info-panel[aria-hidden="false"] {
@@ -103,7 +114,6 @@ body {
   transition-delay: 0s;
 }
 
-/* Контент по центру, узкая колонка */
 .info-content {
   width: min(640px, 100%);
   margin: 0 auto;
@@ -112,36 +122,34 @@ body {
   line-height: 1.25;
 }
 
-/* Заголовок (первый абзац) — крупный serif */
 .info-content .lead {
-  font-size: clamp(24px, 4.6vw, 42px);
+  font-size: clamp(20px, 4.2vw, 38px);
   font-weight: 500;
   letter-spacing: 0.005em;
-  margin: 0 0 28px 0;
+  margin: 0 0 24px 0;
+  color: var(--fg);
 }
 
-/* Список ролей — одна колонка, по центру, равномерный ритм */
 .info-content .roles {
   display: grid;
   justify-items: center;
-  gap: 10px;
-  margin: 0 0 32px 0;
-  font-size: clamp(18px, 3.2vw, 30px);
-  line-height: 1.25;
-  color: #111;
+  gap: 8px;
+  margin: 0 0 28px 0;
+  font-size: clamp(16px, 3vw, 26px);
+  color: var(--fg);
 }
 
-/* Фаундеры — с лёгким курсивом для имени */
 .info-content .founders {
-  font-size: clamp(18px, 2.6vw, 26px);
+  font-size: clamp(16px, 2.4vw, 22px);
   margin: 10px 0 0 0;
+  color: var(--fg);
 }
 .info-content .founders em,
 .info-content .founders i {
   font-style: italic;
 }
 
-/* КНОПКА ЗАКРЫТИЯ (× в кружке) — правый верх, внутри safe-area */
+/* Кнопка закрытия («×») — в правом верхнем углу, белая рамка */
 .info-close {
   position: fixed;
   top: calc(16px + var(--safe-top));
@@ -151,8 +159,8 @@ body {
   line-height: 36px;
   border-radius: 999px;
   background: transparent;
-  color: #111;
-  border: 2px solid #111;
+  color: var(--fg);
+  border: 2px solid var(--fg);
   display: grid;
   place-items: center;
   cursor: pointer;
@@ -160,10 +168,10 @@ body {
   padding: 0;
 }
 .info-close:hover { opacity: .85; }
-.info-close:focus-visible { outline: 2px solid #666; outline-offset: 3px; }
+.info-close:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
 
 /* Уважение к reduced motion */
 @media (prefers-reduced-motion: reduce) {
+  .wordmark,
   .info-panel { transition: none; }
-  .info-btn { transition: none; }
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -19,7 +19,6 @@
 
   --font-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Segoe UI", Roboto, Arial, "Helvetica Neue", Helvetica, system-ui, sans-serif;
 
-  --panel-delay: 0s;
 }
 
 * { box-sizing: border-box; }
@@ -33,44 +32,45 @@ body {
   line-height: 1.4;
 }
 
-.app {
+.app{
   min-height: 100svh;
   padding:
     calc(var(--padY) + var(--safe-top-active))
     calc(var(--padX) + var(--safe-right-active))
     calc(var(--padY) + var(--safe-bottom-active))
     calc(var(--padX) + var(--safe-left-active));
-  display: grid;
-  place-items: center;
   position: relative;
   overscroll-behavior: none;
 }
 
-/* СЛОВО-ЗНАК: состояние по умолчанию — видно */
-.wordmark {
-  margin: 0;
+.hero{
+  height: calc(
+    100svh - (var(--padY) + var(--safe-top-active)) - (var(--padY) + var(--safe-bottom-active))
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  font-weight: 700;
-  line-height: 1.05;
-  letter-spacing: 0.01em;
-  font-size: clamp(28px, 10.5vw, 88px);
-  max-width: min(90cqw, 92vw);
+}
+
+/* Слово-знак */
+.wordmark{
+  margin:0;
+  font-weight:700;
+  letter-spacing:.01em;
+  line-height:1.05;
+  font-size: clamp(28px, 10.5vw, 92px);
+  max-width: 92vw;
   transition:
-    opacity 1.2s cubic-bezier(.16,1,.3,1),
-    transform 1.2s cubic-bezier(.16,1,.3,1),
-    filter 1.2s cubic-bezier(.16,1,.3,1);
+    opacity 1.4s cubic-bezier(.16,1,.3,1),
+    transform 1.4s cubic-bezier(.16,1,.3,1),
+    filter 1.4s cubic-bezier(.16,1,.3,1);
 }
 
-.panel-open .wordmark {
-  opacity: 0.15;
-  transform: translateY(6px) scale(0.985);
-  filter: blur(0.2px);
-}
-
-@media (max-width: 380px) {
-  .wordmark {
-    font-size: clamp(26px, 9.2vw, 64px);
-  }
+.panel-open .wordmark{
+  opacity:.12;
+  transform: translateY(8px) scale(.972);
+  filter: blur(.3px);
 }
 
 .menu-btn {
@@ -97,8 +97,8 @@ body {
   height: 2px;
   background: var(--fg);
   transition:
-    transform 0.6s cubic-bezier(.16,1,.3,1),
-    opacity 0.6s cubic-bezier(.16,1,.3,1);
+    transform 0.7s cubic-bezier(.16,1,.3,1),
+    opacity 0.7s cubic-bezier(.16,1,.3,1);
 }
 
 /* Раскладка в состоянии "бургер" */
@@ -117,72 +117,63 @@ body {
   transform: translateY(0) rotate(-45deg);
 }
 
-.info-panel {
-  position: fixed;
-  inset: 0;
-  background: var(--bg);
-  color: var(--fg);
-  display: grid;
-  place-items: center;
+.info-panel{
+  position:fixed; inset:0;
+  background:var(--bg); color:var(--fg);
+  display:grid; place-items:center;
   padding:
     calc(max(24px, var(--padY)) + var(--safe-top-active))
     calc(max(24px, var(--padX)) + var(--safe-right-active))
     calc(max(28px, var(--padY)) + var(--safe-bottom-active))
     calc(max(24px, var(--padX)) + var(--safe-left-active));
   height: 100lvh;
-  overflow: auto;
-  opacity: 0;
-  transform: translateY(6%);
-  visibility: hidden;
+  overflow:auto;
+
+  opacity:0; transform: translateY(8%);
+  visibility:hidden;
   transition:
-    opacity 1.3s cubic-bezier(.16,1,.3,1) var(--panel-delay),
-    transform 1.3s cubic-bezier(.16,1,.3,1) var(--panel-delay),
-    visibility 0s linear 1.3s;
-  will-change: opacity, transform;
+    opacity 1.6s cubic-bezier(.16,1,.3,1),
+    transform 1.6s cubic-bezier(.16,1,.3,1),
+    visibility 0s linear 1.6s;
+}
+.info-panel[aria-hidden="false"]{
+  opacity:1; transform: translateY(0);
+  visibility:visible; transition-delay:0s,0s,0s;
 }
 
-.info-panel[aria-hidden="false"] {
-  opacity: 1;
-  transform: translateY(0);
-  visibility: visible;
-  transition-delay: var(--panel-delay, 0s), var(--panel-delay, 0s), 0s;
+.info-content{
+  width:min(760px, 100%);
+  margin:0 auto;
+  text-align:center;
+  line-height:1.28;
 }
 
-.info-content {
-  width: min(700px, 100%);
-  margin: 0 auto;
-  text-align: center;
-  line-height: 1.25;
+.info-content .lead{
+  font-size: clamp(24px, 6.6vw, 44px);
+  font-weight:600;
+  letter-spacing:.005em;
+  margin:0 0 28px 0;
+}
+.info-content .roles{
+  display:grid; justify-items:center;
+  gap: 12px;
+  margin: 0 0 34px 0;
+  font-size: clamp(20px, 5.6vw, 30px);
+}
+.info-content .founders{
+  font-size: clamp(18px, 5vw, 26px);
 }
 
-.info-content,
-.info-content * {
-  transition: none !important;
+@keyframes line-rise {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.info-panel[aria-hidden="false"] .line{
+  opacity:0;
+  animation: line-rise 900ms cubic-bezier(.16,1,.3,1) forwards;
+  animation-delay: var(--delay, 0ms);
 }
 
-.info-content .lead {
-  font-size: clamp(22px, 6.2vw, 40px);
-  font-weight: 600;
-  letter-spacing: 0.005em;
-  margin: 0 0 24px 0;
-}
-
-.info-content .roles {
-  display: grid;
-  justify-items: center;
-  gap: 10px;
-  margin: 0 0 28px 0;
-  font-size: clamp(18px, 5.2vw, 28px);
-}
-
-.info-content .founders {
-  font-size: clamp(16px, 4.6vw, 24px);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .wordmark,
-  .info-panel,
-  .menu-btn .bar {
-    transition: none !important;
-  }
+@media (prefers-reduced-motion: reduce){
+  .wordmark, .info-panel, .menu-btn .bar, .line{ transition:none !important; animation:none !important; }
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,22 +1,24 @@
 :root {
-  /* Будут переопределяться из safe-area.js */
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
 
+  /* активные значения, которые можем «замораживать» */
+  --safe-top-active: var(--safe-top);
+  --safe-right-active: var(--safe-right);
+  --safe-bottom-active: var(--safe-bottom);
+  --safe-left-active: var(--safe-left);
+
   --bg: #0A0A0A;
   --fg: #FAFAFA;
   --fg-weak: #C8C8C8;
 
-  --maxw: 1200px;
-  --padX: clamp(16px, 2.5vw, 40px);
-  --padY: clamp(16px, 2.5vh, 40px);
+  --padX: clamp(16px, 4vw, 28px);
+  --padY: clamp(16px, 4svh, 36px);
 
   --font-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Segoe UI", Roboto, Arial, "Helvetica Neue", Helvetica, system-ui, sans-serif;
-  --lh: 1.1;
 
-  --panel-duration: 1.3s;
   --panel-delay: 0s;
 }
 
@@ -32,44 +34,49 @@ body {
 }
 
 .app {
-  min-height: 100svh; /* корректнее, чем 100vh на iOS */
+  min-height: 100svh;
   padding:
-    calc(var(--padY) + var(--safe-top))
-    calc(var(--padX) + var(--safe-right))
-    calc(var(--padY) + var(--safe-bottom))
-    calc(var(--padX) + var(--safe-left));
+    calc(var(--padY) + var(--safe-top-active))
+    calc(var(--padX) + var(--safe-right-active))
+    calc(var(--padY) + var(--safe-bottom-active))
+    calc(var(--padX) + var(--safe-left-active));
   display: grid;
   place-items: center;
   position: relative;
+  overscroll-behavior: none;
 }
 
 /* СЛОВО-ЗНАК: состояние по умолчанию — видно */
 .wordmark {
   margin: 0;
-  font-weight: 600;
-  letter-spacing: 0.02em;
   text-align: center;
-  line-height: var(--lh);
-  font-size: clamp(28px, 11vw, 96px);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: 0.01em;
+  font-size: clamp(28px, 10.5vw, 88px);
+  max-width: min(90cqw, 92vw);
   transition:
     opacity 1.2s cubic-bezier(.16,1,.3,1),
     transform 1.2s cubic-bezier(.16,1,.3,1),
     filter 1.2s cubic-bezier(.16,1,.3,1);
-  will-change: opacity, transform, filter;
 }
 
-/* Когда панель открыта — «уходим в глубину» */
 .panel-open .wordmark {
   opacity: 0.15;
   transform: translateY(6px) scale(0.985);
   filter: blur(0.2px);
 }
 
-/* БУРГЕР-КНОПКА в правом верхнем углу, уважает safe-areas */
+@media (max-width: 380px) {
+  .wordmark {
+    font-size: clamp(26px, 9.2vw, 64px);
+  }
+}
+
 .menu-btn {
   position: fixed;
-  top: calc(16px + var(--safe-top));
-  right: calc(16px + var(--safe-right));
+  top: calc(16px + var(--safe-top-active));
+  right: calc(16px + var(--safe-right-active));
   width: 36px;
   height: 36px;
   display: grid;
@@ -78,7 +85,7 @@ body {
   border: none;
   padding: 0;
   cursor: pointer;
-  z-index: 10;
+  z-index: 20;
 }
 
 .menu-btn:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
@@ -110,7 +117,6 @@ body {
   transform: translateY(0) rotate(-45deg);
 }
 
-/* ИНФО-ПАНЕЛЬ: полноэкранный оверлей, тот же цвет, что и фон */
 .info-panel {
   position: fixed;
   inset: 0;
@@ -119,20 +125,19 @@ body {
   display: grid;
   place-items: center;
   padding:
-    calc(max(var(--padY), 24px) + var(--safe-top))
-    calc(max(var(--padX), 24px) + var(--safe-right))
-    calc(max(var(--padY), 24px) + var(--safe-bottom))
-    calc(max(var(--padX), 24px) + var(--safe-left));
+    calc(max(24px, var(--padY)) + var(--safe-top-active))
+    calc(max(24px, var(--padX)) + var(--safe-right-active))
+    calc(max(28px, var(--padY)) + var(--safe-bottom-active))
+    calc(max(24px, var(--padX)) + var(--safe-left-active));
+  height: 100lvh;
   overflow: auto;
-
-  /* старт: слегка ниже и прозрачная */
   opacity: 0;
   transform: translateY(6%);
   visibility: hidden;
   transition:
-    opacity var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
-    transform var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
-    visibility 0s linear var(--panel-duration);
+    opacity 1.3s cubic-bezier(.16,1,.3,1) var(--panel-delay),
+    transform 1.3s cubic-bezier(.16,1,.3,1) var(--panel-delay),
+    visibility 0s linear 1.3s;
   will-change: opacity, transform;
 }
 
@@ -144,10 +149,9 @@ body {
 }
 
 .info-content {
-  width: min(640px, 100%);
+  width: min(700px, 100%);
   margin: 0 auto;
   text-align: center;
-  font-family: ui-serif, "Georgia", "Times New Roman", Times, serif;
   line-height: 1.25;
 }
 
@@ -157,34 +161,28 @@ body {
 }
 
 .info-content .lead {
-  font-size: clamp(20px, 4.2vw, 38px);
-  font-weight: 500;
+  font-size: clamp(22px, 6.2vw, 40px);
+  font-weight: 600;
   letter-spacing: 0.005em;
   margin: 0 0 24px 0;
-  color: var(--fg);
 }
 
 .info-content .roles {
   display: grid;
   justify-items: center;
-  gap: 8px;
+  gap: 10px;
   margin: 0 0 28px 0;
-  font-size: clamp(16px, 3vw, 26px);
-  color: var(--fg);
+  font-size: clamp(18px, 5.2vw, 28px);
 }
 
 .info-content .founders {
-  font-size: clamp(16px, 2.4vw, 22px);
-  margin: 10px 0 0 0;
-  color: var(--fg);
-}
-.info-content .founders em,
-.info-content .founders i {
-  font-style: italic;
+  font-size: clamp(16px, 4.6vw, 24px);
 }
 
-/* Уважение к reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .menu-btn .bar { transition: none; }
-  .wordmark, .info-panel { transition: none; }
+  .wordmark,
+  .info-panel,
+  .menu-btn .bar {
+    transition: none !important;
+  }
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,39 +1,47 @@
-:root {
+:root{
+  /* базовые safe-insets (из safe-area.js будут перезаписываться активные) */
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
 
-  /* активные значения, которые можем «замораживать» */
   --safe-top-active: var(--safe-top);
   --safe-right-active: var(--safe-right);
   --safe-bottom-active: var(--safe-bottom);
   --safe-left-active: var(--safe-left);
 
-  --bg: #0A0A0A;
-  --fg: #FAFAFA;
-  --fg-weak: #C8C8C8;
+  --bg:#0A0A0A;
+  --fg:#FAFAFA;
+  --fg-weak:#C8C8C8;
 
   --padX: clamp(16px, 4vw, 28px);
   --padY: clamp(16px, 4svh, 36px);
 
-  --font-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Segoe UI", Roboto, Arial, "Helvetica Neue", Helvetica, system-ui, sans-serif;
+  /* управляемая длительность и задержка панели */
+  --panel-duration: 1.6s;
+  --panel-delay: .12s;
 
+  /* высота видимой области, зададим из JS точно */
+  --vh-usable: 100svh;
+
+  /* масштаб инфо-контента (автофит) */
+  --panel-scale: 1;
+
+  --font-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Segoe UI", Roboto, Arial, "Helvetica Neue", Helvetica, system-ui, sans-serif;
 }
 
-* { box-sizing: border-box; }
-html, body { height: 100%; }
-
-html { background: var(--bg); color: var(--fg); }
-body {
-  margin: 0;
+*{ box-sizing: border-box; }
+html, body{ height: 100%; }
+html{ background: var(--bg); color: var(--fg); }
+body{
+  margin:0;
   -webkit-font-smoothing: antialiased;
   font-family: var(--font-sans);
   line-height: 1.4;
 }
 
 .app{
-  min-height: 100svh;
+  min-height: var(--vh-usable);
   padding:
     calc(var(--padY) + var(--safe-top-active))
     calc(var(--padX) + var(--safe-right-active))
@@ -45,77 +53,52 @@ body {
 
 .hero{
   height: calc(
-    100svh - (var(--padY) + var(--safe-top-active)) - (var(--padY) + var(--safe-bottom-active))
+    var(--vh-usable) - (var(--padY) + var(--safe-top-active)) - (var(--padY) + var(--safe-bottom-active))
   );
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
+  display:flex; align-items:center; justify-content:center;
+  text-align:center;
 }
 
-/* Слово-знак */
 .wordmark{
   margin:0;
-  font-weight:700;
+  font-weight:800;
   letter-spacing:.01em;
   line-height:1.05;
-  font-size: clamp(28px, 10.5vw, 92px);
+  font-size: clamp(28px, 10.5vw, 96px);
   max-width: 92vw;
   transition:
     opacity 1.4s cubic-bezier(.16,1,.3,1),
     transform 1.4s cubic-bezier(.16,1,.3,1),
     filter 1.4s cubic-bezier(.16,1,.3,1);
 }
-
+.panel-opening .wordmark,
 .panel-open .wordmark{
   opacity:.12;
   transform: translateY(8px) scale(.972);
   filter: blur(.3px);
 }
+.panel-closing .wordmark{
+  transition-duration: 1.4s;
+}
 
-.menu-btn {
-  position: fixed;
+.menu-btn{
+  position:fixed;
   top: calc(16px + var(--safe-top-active));
   right: calc(16px + var(--safe-right-active));
-  width: 36px;
-  height: 36px;
-  display: grid;
-  place-items: center;
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  z-index: 20;
+  width:36px; height:36px; display:grid; place-items:center;
+  background:transparent; border:none; padding:0; cursor:pointer; z-index:20;
 }
-
-.menu-btn:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
-
-/* Три полоски бургера */
-.menu-btn .bar {
-  position: absolute;
-  width: 22px;
-  height: 2px;
-  background: var(--fg);
-  transition:
-    transform 0.7s cubic-bezier(.16,1,.3,1),
-    opacity 0.7s cubic-bezier(.16,1,.3,1);
+.menu-btn:focus-visible{ outline: 2px solid var(--fg-weak); outline-offset: 3px; }
+.menu-btn .bar{
+  position:absolute; width:22px; height:2px; background:var(--fg);
+  transition: transform .7s cubic-bezier(.16,1,.3,1), opacity .7s cubic-bezier(.16,1,.3,1);
 }
-
-/* Раскладка в состоянии "бургер" */
-.menu-btn .top    { transform: translateY(-6px); }
-.menu-btn .middle { transform: translateY(0); }
-.menu-btn .bottom { transform: translateY(6px); }
-
-/* Состояние "открыто" — превращаемся в крест */
-.menu-btn.is-open .top {
-  transform: translateY(0) rotate(45deg);
-}
-.menu-btn.is-open .middle {
-  opacity: 0;
-}
-.menu-btn.is-open .bottom {
-  transform: translateY(0) rotate(-45deg);
-}
+.menu-btn .top{ transform: translateY(-6px); }
+.menu-btn .middle{ transform: translateY(0); }
+.menu-btn .bottom{ transform: translateY(6px); }
+.menu-btn.is-open .top{ transform: translateY(0) rotate(45deg); }
+.menu-btn.is-open .middle{ opacity:0; }
+.menu-btn.is-open .bottom{ transform: translateY(0) rotate(-45deg); }
 
 .info-panel{
   position:fixed; inset:0;
@@ -132,25 +115,29 @@ body {
   opacity:0; transform: translateY(8%);
   visibility:hidden;
   transition:
-    opacity 1.6s cubic-bezier(.16,1,.3,1),
-    transform 1.6s cubic-bezier(.16,1,.3,1),
-    visibility 0s linear 1.6s;
+    opacity var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
+    transform var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
+    visibility 0s linear var(--panel-duration);
 }
 .info-panel[aria-hidden="false"]{
   opacity:1; transform: translateY(0);
-  visibility:visible; transition-delay:0s,0s,0s;
+  visibility:visible; transition-delay: var(--panel-delay), var(--panel-delay), 0s;
+}
+
+.info-fit{
+  transform: scale(var(--panel-scale));
+  transform-origin: top center;
 }
 
 .info-content{
-  width:min(760px, 100%);
+  width:min(780px, 100%);
   margin:0 auto;
   text-align:center;
   line-height:1.28;
 }
-
 .info-content .lead{
   font-size: clamp(24px, 6.6vw, 44px);
-  font-weight:600;
+  font-weight:700;
   letter-spacing:.005em;
   margin:0 0 28px 0;
 }
@@ -164,16 +151,26 @@ body {
   font-size: clamp(18px, 5vw, 26px);
 }
 
-@keyframes line-rise {
-  from { opacity: 0; transform: translateY(14px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
+@keyframes line-rise { from {opacity:0; transform: translateY(14px);} to {opacity:1; transform: translateY(0);} }
+@keyframes line-fall { from {opacity:1; transform: translateY(0);}     to {opacity:0; transform: translateY(14px);} }
+
 .info-panel[aria-hidden="false"] .line{
   opacity:0;
-  animation: line-rise 900ms cubic-bezier(.16,1,.3,1) forwards;
+  animation: line-rise 1.1s cubic-bezier(.16,1,.3,1) forwards;
   animation-delay: var(--delay, 0ms);
 }
 
+.panel-closing .line{
+  animation: line-fall 900ms cubic-bezier(.16,1,.3,1) forwards;
+  animation-delay: var(--delay, 0ms);
+}
+
+@media (max-width:380px){
+  .wordmark{ font-size: clamp(26px, 9.2vw, 70px); }
+}
+
 @media (prefers-reduced-motion: reduce){
-  .wordmark, .info-panel, .menu-btn .bar, .line{ transition:none !important; animation:none !important; }
+  .wordmark, .info-panel, .menu-btn .bar, .line{
+    transition:none !important; animation:none !important;
+  }
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -48,9 +48,9 @@ body {
   text-align: center;
   line-height: var(--lh);
   font-size: clamp(28px, 11vw, 96px);
-  transition: opacity .6s cubic-bezier(.2,.8,.2,1),
-              transform .6s cubic-bezier(.2,.8,.2,1),
-              filter .6s cubic-bezier(.2,.8,.2,1);
+  transition: opacity 1.2s cubic-bezier(.2,.8,.2,1),
+              transform 1.2s cubic-bezier(.2,.8,.2,1),
+              filter 1.2s cubic-bezier(.2,.8,.2,1);
   will-change: opacity, transform, filter;
 }
 
@@ -61,8 +61,8 @@ body {
   filter: blur(0.2px);
 }
 
-/* Кнопка "i" — правый верх, внутри safe-area */
-.info-btn {
+/* БУРГЕР-КНОПКА в правом верхнем углу, уважает safe-areas */
+.menu-btn {
   position: fixed;
   top: calc(16px + var(--safe-top));
   right: calc(16px + var(--safe-right));
@@ -71,15 +71,39 @@ body {
   display: grid;
   place-items: center;
   background: transparent;
-  color: var(--fg);
   border: none;
   padding: 0;
   cursor: pointer;
-  opacity: 0.9;
-  transition: opacity .2s ease, transform .2s ease;
+  z-index: 10;
 }
-.info-btn:hover { opacity: 1; transform: scale(1.03); }
-.info-btn:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
+
+.menu-btn:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
+
+/* Три полоски бургера */
+.menu-btn .bar {
+  position: absolute;
+  width: 22px;
+  height: 2px;
+  background: var(--fg);
+  transition: transform 0.6s cubic-bezier(.2,.8,.2,1),
+              opacity 0.6s cubic-bezier(.2,.8,.2,1);
+}
+
+/* Раскладка в состоянии "бургер" */
+.menu-btn .top    { transform: translateY(-6px); }
+.menu-btn .middle { transform: translateY(0); }
+.menu-btn .bottom { transform: translateY(6px); }
+
+/* Состояние "открыто" — превращаемся в крест */
+.menu-btn.is-open .top {
+  transform: translateY(0) rotate(45deg);
+}
+.menu-btn.is-open .middle {
+  opacity: 0;
+}
+.menu-btn.is-open .bottom {
+  transform: translateY(0) rotate(-45deg);
+}
 
 /* ИНФО-ПАНЕЛЬ: полноэкранный оверлей, тот же цвет, что и фон */
 .info-panel {
@@ -101,9 +125,9 @@ body {
   transform: translateY(6%);
   visibility: hidden;
   transition:
-    opacity .65s cubic-bezier(.2,.8,.2,1),
-    transform .65s cubic-bezier(.2,.8,.2,1),
-    visibility 0s linear .65s;
+    opacity 1.3s cubic-bezier(.2,.8,.2,1),
+    transform 1.3s cubic-bezier(.2,.8,.2,1),
+    visibility 0s linear 1.3s;
   will-change: opacity, transform;
 }
 
@@ -172,6 +196,6 @@ body {
 
 /* Уважение к reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .wordmark,
-  .info-panel { transition: none; }
+  .menu-btn .bar { transition: none; }
+  .wordmark, .info-panel { transition: none; }
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -71,55 +71,96 @@ body {
 .info-btn:hover { opacity: 1; transform: scale(1.03); }
 .info-btn:focus-visible { outline: 2px solid var(--fg-weak); outline-offset: 3px; }
 
-/* Инфо-панель (диалог) */
+/* ПОЛНОЭКРАННАЯ СВЕТЛАЯ ПАНЕЛЬ */
 .info-panel {
   position: fixed;
-  inset: auto 0 0 0; /* снизу экрана */
+  inset: 0;
+  background: #FAFAFA;
+  color: #111;
+  display: grid;
+  place-items: center;
+  /* плавное появление */
+  opacity: 0;
+  transform: translateY(2%);
+  visibility: hidden;
+  transition:
+    opacity .35s cubic-bezier(.2,.8,.2,1),
+    transform .35s cubic-bezier(.2,.8,.2,1),
+    visibility 0s linear .35s; /* скрыть клики, когда невидима */
+  /* учёт safe-areas через внутренние паддинги контейнера */
   padding:
-    0
-    calc(var(--padX) + var(--safe-right))
-    calc(var(--padY) + var(--safe-bottom))
-    calc(var(--padX) + var(--safe-left));
-  background: color-mix(in srgb, var(--bg) 94%, black 6%);
-  border-top: 1px solid rgba(255,255,255,.08);
-  max-height: 70svh;
-  transform: translateY(100%);
-  transition: transform .45s cubic-bezier(.2,.8,.2,1);
-  will-change: transform;
+    calc(max(var(--padY), 24px) + var(--safe-top))
+    calc(max(var(--padX), 24px) + var(--safe-right))
+    calc(max(var(--padY), 24px) + var(--safe-bottom))
+    calc(max(var(--padX), 24px) + var(--safe-left));
   overflow: auto;
 }
-.info-panel[aria-hidden="false"] {
-  transform: translateY(0);
-}
-.info-content {
-  margin: 24px auto 0;
-  max-width: min(800px, calc(100% - var(--safe-left) - var(--safe-right)));
-  color: var(--fg);
-}
-.info-content p { margin: 0 0 16px 0; }
 
-.lead {
-  font-size: clamp(16px, 2.4vw, 28px);
+.info-panel[aria-hidden="false"] {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+/* Контент по центру, узкая колонка */
+.info-content {
+  width: min(640px, 100%);
+  margin: 0 auto;
+  text-align: center;
+  font-family: ui-serif, "Georgia", "Times New Roman", Times, serif;
   line-height: 1.25;
 }
-.roles {
+
+/* Заголовок (первый абзац) — крупный serif */
+.info-content .lead {
+  font-size: clamp(24px, 4.6vw, 42px);
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  margin: 0 0 28px 0;
+}
+
+/* Список ролей — одна колонка, по центру, равномерный ритм */
+.info-content .roles {
   display: grid;
-  gap: 6px;
-  font-size: clamp(14px, 1.8vw, 20px);
-  color: var(--fg-weak);
+  justify-items: center;
+  gap: 10px;
+  margin: 0 0 32px 0;
+  font-size: clamp(18px, 3.2vw, 30px);
+  line-height: 1.25;
+  color: #111;
 }
-.founders {
-  margin-top: 20px;
-  font-size: clamp(14px, 1.8vw, 20px);
+
+/* Фаундеры — с лёгким курсивом для имени */
+.info-content .founders {
+  font-size: clamp(18px, 2.6vw, 26px);
+  margin: 10px 0 0 0;
 }
-.founders a {
-  color: var(--fg);
-  text-decoration: none;
-  border-bottom: 1px solid rgba(255,255,255,.25);
+.info-content .founders em,
+.info-content .founders i {
+  font-style: italic;
 }
-.founders a:hover {
-  border-bottom-color: rgba(255,255,255,.6);
+
+/* КНОПКА ЗАКРЫТИЯ (× в кружке) — правый верх, внутри safe-area */
+.info-close {
+  position: fixed;
+  top: calc(16px + var(--safe-top));
+  right: calc(16px + var(--safe-right));
+  width: 36px;
+  height: 36px;
+  line-height: 36px;
+  border-radius: 999px;
+  background: transparent;
+  color: #111;
+  border: 2px solid #111;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-size: 24px;
+  padding: 0;
 }
+.info-close:hover { opacity: .85; }
+.info-close:focus-visible { outline: 2px solid #666; outline-offset: 3px; }
 
 /* Уважение к reduced motion */
 @media (prefers-reduced-motion: reduce) {

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,10 +3,12 @@
   const infoBtn = document.getElementById('infoBtn');
   const infoPanel = document.getElementById('infoPanel');
   const infoClose = document.getElementById('infoClose');
+  const root = document.documentElement;
 
   function openPanel() {
     infoBtn.setAttribute('aria-expanded', 'true');
     infoPanel.setAttribute('aria-hidden', 'false');
+    root.classList.add('panel-open');
     // блокируем прокрутку фона на iOS
     document.documentElement.style.overflow = 'hidden';
     document.body.style.overflow = 'hidden';
@@ -15,6 +17,7 @@
   function closePanel() {
     infoBtn.setAttribute('aria-expanded', 'false');
     infoPanel.setAttribute('aria-hidden', 'true');
+    root.classList.remove('panel-open');
     document.documentElement.style.overflow = '';
     document.body.style.overflow = '';
   }
@@ -25,7 +28,7 @@
   }
 
   infoBtn.addEventListener('click', togglePanel);
-  infoClose.addEventListener('click', closePanel);
+  if (infoClose) infoClose.addEventListener('click', closePanel);
 
   // Закрытие по Esc
   document.addEventListener('keydown', (e) => {

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,37 +1,39 @@
 // assets/main.js
 (function () {
-  const menuBtn   = document.getElementById('menuBtn');
+  const menuBtn = document.getElementById('menuBtn');
   const infoPanel = document.getElementById('infoPanel');
   const root = document.documentElement;
 
   function openPanel() {
-    // 1) сначала "углубляем" слово и меняем бургер → крест
+    if (window.__freezeSafeAreas) window.__freezeSafeAreas();
+
     root.classList.add('panel-open');
     menuBtn.classList.add('is-open');
     menuBtn.setAttribute('aria-expanded', 'true');
 
-    // 2) задаём небольшую задержку для панели (мягкое стадирование)
     root.style.setProperty('--panel-delay', '.12s');
 
-    // 3) показываем панель
     infoPanel.setAttribute('aria-hidden', 'false');
 
-    // 4) блокируем фон
     document.documentElement.style.overflow = 'hidden';
     document.body.style.overflow = 'hidden';
   }
 
   function closePanel() {
-    // без задержки на закрытие
     root.style.setProperty('--panel-delay', '0s');
 
-    menuBtn.classList.remove('is-open');
-    menuBtn.setAttribute('aria-expanded', 'false');
     infoPanel.setAttribute('aria-hidden', 'true');
     root.classList.remove('panel-open');
 
+    menuBtn.classList.remove('is-open');
+    menuBtn.setAttribute('aria-expanded', 'false');
+
     document.documentElement.style.overflow = '';
     document.body.style.overflow = '';
+
+    setTimeout(() => {
+      if (window.__unfreezeSafeAreas) window.__unfreezeSafeAreas();
+    }, 300);
   }
 
   function togglePanel() {
@@ -40,19 +42,17 @@
   }
 
   menuBtn.addEventListener('click', togglePanel);
-  // Закрытие по Esc
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') closePanel();
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') closePanel();
   });
 
-  // Клик по фону (вне контента) — закрыть
-  infoPanel.addEventListener('click', (e) => {
-    const content = e.currentTarget.querySelector('.info-content');
-    if (e.target === e.currentTarget || !content.contains(e.target)) {
+  infoPanel.addEventListener('click', (event) => {
+    const content = event.currentTarget.querySelector('.info-content');
+    if (event.target === event.currentTarget || !content.contains(event.target)) {
       closePanel();
     }
   });
 
-  // Старт: панель скрыта
-  closePanel();
+  infoPanel.setAttribute('aria-hidden', 'true');
 })();

--- a/assets/main.js
+++ b/assets/main.js
@@ -2,15 +2,21 @@
 (function () {
   const infoBtn = document.getElementById('infoBtn');
   const infoPanel = document.getElementById('infoPanel');
+  const infoClose = document.getElementById('infoClose');
 
   function openPanel() {
     infoBtn.setAttribute('aria-expanded', 'true');
     infoPanel.setAttribute('aria-hidden', 'false');
+    // блокируем прокрутку фона на iOS
+    document.documentElement.style.overflow = 'hidden';
+    document.body.style.overflow = 'hidden';
   }
 
   function closePanel() {
     infoBtn.setAttribute('aria-expanded', 'false');
     infoPanel.setAttribute('aria-hidden', 'true');
+    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
   }
 
   function togglePanel() {
@@ -19,18 +25,21 @@
   }
 
   infoBtn.addEventListener('click', togglePanel);
+  infoClose.addEventListener('click', closePanel);
 
-  // Закрытие по Escape
+  // Закрытие по Esc
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') closePanel();
   });
 
-  // Клик вне содержимого панели (если открыта)
+  // Клик по фону (вне контента) — закрыть
   infoPanel.addEventListener('click', (e) => {
-    // Закрываем, если кликнули по фону панели, а не по контенту
-    if (e.target === infoPanel) closePanel();
+    const content = e.currentTarget.querySelector('.info-content');
+    if (e.target === e.currentTarget || !content.contains(e.target)) {
+      closePanel();
+    }
   });
 
-  // Стартовое состояние — панель скрыта
+  // Старт: панель скрыта
   closePanel();
 })();

--- a/assets/main.js
+++ b/assets/main.js
@@ -2,24 +2,34 @@
 (function () {
   const menuBtn   = document.getElementById('menuBtn');
   const infoPanel = document.getElementById('infoPanel');
-  const infoClose = document.getElementById('infoClose');
   const root = document.documentElement;
 
   function openPanel() {
+    // 1) сначала "углубляем" слово и меняем бургер → крест
+    root.classList.add('panel-open');
     menuBtn.classList.add('is-open');
     menuBtn.setAttribute('aria-expanded', 'true');
+
+    // 2) задаём небольшую задержку для панели (мягкое стадирование)
+    root.style.setProperty('--panel-delay', '.12s');
+
+    // 3) показываем панель
     infoPanel.setAttribute('aria-hidden', 'false');
-    root.classList.add('panel-open');
-    // блокируем прокрутку фона на iOS
+
+    // 4) блокируем фон
     document.documentElement.style.overflow = 'hidden';
     document.body.style.overflow = 'hidden';
   }
 
   function closePanel() {
+    // без задержки на закрытие
+    root.style.setProperty('--panel-delay', '0s');
+
     menuBtn.classList.remove('is-open');
     menuBtn.setAttribute('aria-expanded', 'false');
     infoPanel.setAttribute('aria-hidden', 'true');
     root.classList.remove('panel-open');
+
     document.documentElement.style.overflow = '';
     document.body.style.overflow = '';
   }
@@ -30,8 +40,6 @@
   }
 
   menuBtn.addEventListener('click', togglePanel);
-  if (infoClose) infoClose.addEventListener('click', closePanel);
-
   // Закрытие по Esc
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') closePanel();

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,12 +1,13 @@
 // assets/main.js
 (function () {
-  const infoBtn = document.getElementById('infoBtn');
+  const menuBtn   = document.getElementById('menuBtn');
   const infoPanel = document.getElementById('infoPanel');
   const infoClose = document.getElementById('infoClose');
   const root = document.documentElement;
 
   function openPanel() {
-    infoBtn.setAttribute('aria-expanded', 'true');
+    menuBtn.classList.add('is-open');
+    menuBtn.setAttribute('aria-expanded', 'true');
     infoPanel.setAttribute('aria-hidden', 'false');
     root.classList.add('panel-open');
     // блокируем прокрутку фона на iOS
@@ -15,7 +16,8 @@
   }
 
   function closePanel() {
-    infoBtn.setAttribute('aria-expanded', 'false');
+    menuBtn.classList.remove('is-open');
+    menuBtn.setAttribute('aria-expanded', 'false');
     infoPanel.setAttribute('aria-hidden', 'true');
     root.classList.remove('panel-open');
     document.documentElement.style.overflow = '';
@@ -23,11 +25,11 @@
   }
 
   function togglePanel() {
-    const expanded = infoBtn.getAttribute('aria-expanded') === 'true';
+    const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
     expanded ? closePanel() : openPanel();
   }
 
-  infoBtn.addEventListener('click', togglePanel);
+  menuBtn.addEventListener('click', togglePanel);
   if (infoClose) infoClose.addEventListener('click', closePanel);
 
   // Закрытие по Esc

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,8 +1,25 @@
 // assets/main.js
 (function () {
-  const menuBtn = document.getElementById('menuBtn');
+  const menuBtn   = document.getElementById('menuBtn');
   const infoPanel = document.getElementById('infoPanel');
   const root = document.documentElement;
+
+  function prepareLines() {
+    const nodes = [];
+    const lead = infoPanel.querySelector('.lead');
+    if (lead) nodes.push(lead);
+
+    const roles = infoPanel.querySelectorAll('.roles span');
+    roles.forEach((node) => nodes.push(node));
+
+    const founders = infoPanel.querySelector('.founders');
+    if (founders) nodes.push(founders);
+
+    nodes.forEach((el, index) => {
+      el.classList.add('line');
+      el.style.setProperty('--delay', `${160 + index * 95}ms`);
+    });
+  }
 
   function openPanel() {
     if (window.__freezeSafeAreas) window.__freezeSafeAreas();
@@ -11,17 +28,16 @@
     menuBtn.classList.add('is-open');
     menuBtn.setAttribute('aria-expanded', 'true');
 
-    root.style.setProperty('--panel-delay', '.12s');
-
-    infoPanel.setAttribute('aria-hidden', 'false');
+    setTimeout(() => {
+      prepareLines();
+      infoPanel.setAttribute('aria-hidden', 'false');
+    }, 120);
 
     document.documentElement.style.overflow = 'hidden';
     document.body.style.overflow = 'hidden';
   }
 
   function closePanel() {
-    root.style.setProperty('--panel-delay', '0s');
-
     infoPanel.setAttribute('aria-hidden', 'true');
     root.classList.remove('panel-open');
 
@@ -37,8 +53,7 @@
   }
 
   function togglePanel() {
-    const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
-    expanded ? closePanel() : openPanel();
+    menuBtn.getAttribute('aria-expanded') === 'true' ? closePanel() : openPanel();
   }
 
   menuBtn.addEventListener('click', togglePanel);

--- a/assets/safe-area.js
+++ b/assets/safe-area.js
@@ -2,65 +2,64 @@
 (function () {
   const docEl = document.documentElement;
 
-  function readNumberVar(name) {
-    const value = getComputedStyle(docEl).getPropertyValue(name).trim();
-    const parsed = parseFloat(value);
-    return Number.isNaN(parsed) ? 0 : parsed;
+  function readCssNumber(name){
+    const v = getComputedStyle(docEl).getPropertyValue(name).trim();
+    const n = parseFloat(v);
+    return Number.isNaN(n) ? 0 : n;
   }
 
   function updateSafeAreaVars() {
     const vv = window.visualViewport;
-    let top = readNumberVar('--safe-top');
-    let right = readNumberVar('--safe-right');
-    let bottom = readNumberVar('--safe-bottom');
-    let left = readNumberVar('--safe-left');
+    let top = readCssNumber('--safe-top');
+    let right = readCssNumber('--safe-right');
+    let bottom = readCssNumber('--safe-bottom');
+    let left = readCssNumber('--safe-left');
 
-    if (vv) {
-      const viewportWidth = Math.round(vv.width);
-      const windowWidth = window.innerWidth;
-      const viewportHeight = Math.round(vv.height);
-      const windowHeight = window.innerHeight;
-      const offsetTop = Math.round(vv.offsetTop);
-      const offsetLeft = Math.round(vv.offsetLeft);
-      const verticalGap = Math.max(0, windowHeight - viewportHeight);
+    let usableH = window.innerHeight;
+    if (vv){
+      const W = window.innerWidth;
+      const H = window.innerHeight;
+      const w = Math.round(vv.width);
+      const h = Math.round(vv.height);
+      const offT = Math.round(vv.offsetTop);
+      const offL = Math.round(vv.offsetLeft);
+      const vGap = Math.max(0, H - h);
 
-      top = Math.max(top, offsetTop);
-      left = Math.max(left, offsetLeft);
-      right = Math.max(right, Math.max(0, (windowWidth - viewportWidth) - offsetLeft));
-      bottom = Math.max(bottom, Math.max(0, verticalGap - offsetTop));
+      top = Math.max(top, offT);
+      left = Math.max(left, offL);
+      right = Math.max(right, Math.max(0, (W - w) - offL));
+      bottom = Math.max(bottom, Math.max(0, vGap - offT));
+
+      usableH = h;
     }
 
-    if (!docEl.classList.contains('panel-open')) {
+    const panelOpen = docEl.classList.contains('panel-open') ||
+                      docEl.classList.contains('panel-opening') ||
+                      docEl.classList.contains('panel-closing');
+
+    if (!panelOpen){
       docEl.style.setProperty('--safe-top-active', `${top}px`);
       docEl.style.setProperty('--safe-right-active', `${right}px`);
       docEl.style.setProperty('--safe-bottom-active', `${bottom}px`);
       docEl.style.setProperty('--safe-left-active', `${left}px`);
     }
+
+    docEl.style.setProperty('--vh-usable', `${usableH}px`);
   }
 
-  ['resize', 'scroll', 'orientationchange'].forEach((eventName) => {
+  ['resize','scroll','orientationchange'].forEach((eventName) => {
     window.addEventListener(eventName, updateSafeAreaVars, { passive: true });
   });
-
-  if (window.visualViewport) {
-    ['resize', 'scroll'].forEach((eventName) => {
+  if (window.visualViewport){
+    ['resize','scroll'].forEach((eventName) => {
       window.visualViewport.addEventListener(eventName, updateSafeAreaVars, { passive: true });
     });
   }
 
-  window.__freezeSafeAreas = function freeze() {
-    const top = readNumberVar('--safe-top-active');
-    const right = readNumberVar('--safe-right-active');
-    const bottom = readNumberVar('--safe-bottom-active');
-    const left = readNumberVar('--safe-left-active');
-
-    docEl.style.setProperty('--safe-top-active', `${top}px`);
-    docEl.style.setProperty('--safe-right-active', `${right}px`);
-    docEl.style.setProperty('--safe-bottom-active', `${bottom}px`);
-    docEl.style.setProperty('--safe-left-active', `${left}px`);
+  window.__freezeSafeAreas = function (){
+    // просто перестаём обновлять активные переменные до unfreeze
   };
-
-  window.__unfreezeSafeAreas = function unfreeze() {
+  window.__unfreezeSafeAreas = function (){
     updateSafeAreaVars();
   };
 

--- a/index.html
+++ b/index.html
@@ -17,13 +17,11 @@
       <span aria-hidden="true">CLASSNOE&nbsp;MESTO</span>
     </h1>
 
-    <!-- Кнопка информации (правый верх) -->
-    <button id="infoBtn" class="info-btn" aria-expanded="false" aria-controls="infoPanel" aria-label="Open information panel">
-      <svg viewBox="-50 -50 100 100" width="36" height="36" aria-hidden="true" focusable="false">
-        <circle cx="0" cy="0" r="5" stroke="currentColor" fill="none" stroke-width="3.2"></circle>
-        <line x1="0" y1="-10" x2="0" y2="8" stroke="currentColor" stroke-width="4.6" stroke-linecap="round"></line>
-        <circle cx="0" cy="15" r="2.4" fill="currentColor"></circle>
-      </svg>
+    <!-- Бургер-кнопка (вместо "i") -->
+    <button id="menuBtn" class="menu-btn" aria-expanded="false" aria-controls="infoPanel" aria-label="Open menu">
+      <span class="bar top" aria-hidden="true"></span>
+      <span class="bar middle" aria-hidden="true"></span>
+      <span class="bar bottom" aria-hidden="true"></span>
     </button>
 
     <!-- Инфо-панель (как у LoveFrom: текст, список ролей, «Founded by…») -->

--- a/index.html
+++ b/index.html
@@ -28,26 +28,28 @@
 
     <!-- Инфо-панель (как у LoveFrom: текст, список ролей, «Founded by…») -->
     <aside id="infoPanel" class="info-panel" role="dialog" aria-modal="false" aria-hidden="true">
-      <div class="info-content">
-        <p class="lead">Classnoe Mesto is a <span class="vcut">creative collective.</span></p>
-        <p class="roles">
-          <span>architects</span>
-          <span>artists</span>
-          <span>engineers</span>
-          <span>filmmakers</span>
-          <span>graphic designers</span>
-          <span>industrial designers</span>
-          <span>interaction designers</span>
-          <span>motion designers</span>
-          <span>musicians</span>
-          <span>sound designers</span>
-          <span>type designers</span>
-          <span>writers</span>
-        </p>
-        <p class="founders">
-          Founded by <em>Jony Ive</em><br>
-          with Marc Newson.
-        </p>
+      <div class="info-fit">
+        <div class="info-content">
+          <p class="lead">Classnoe Mesto is a <span class="vcut">creative collective.</span></p>
+          <p class="roles">
+            <span>architects</span>
+            <span>artists</span>
+            <span>engineers</span>
+            <span>filmmakers</span>
+            <span>graphic designers</span>
+            <span>industrial designers</span>
+            <span>interaction designers</span>
+            <span>motion designers</span>
+            <span>musicians</span>
+            <span>sound designers</span>
+            <span>type designers</span>
+            <span>writers</span>
+          </p>
+          <p class="founders">
+            Founded by <em>Jony Ive</em><br>
+            with Marc Newson.
+          </p>
+        </div>
       </div>
     </aside>
   </div>

--- a/index.html
+++ b/index.html
@@ -26,10 +26,6 @@
 
     <!-- Инфо-панель (как у LoveFrom: текст, список ролей, «Founded by…») -->
     <aside id="infoPanel" class="info-panel" role="dialog" aria-modal="false" aria-hidden="true">
-      <!-- close button -->
-      <button id="infoClose" class="info-close" aria-label="Close information panel">
-        <span aria-hidden="true">×</span>
-      </button>
       <div class="info-content">
         <p class="lead">Classnoe Mesto is a <span class="vcut">creative collective.</span></p>
         <p class="roles">

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
 
     <!-- Инфо-панель (как у LoveFrom: текст, список ролей, «Founded by…») -->
     <aside id="infoPanel" class="info-panel" role="dialog" aria-modal="false" aria-hidden="true">
+      <!-- close button -->
+      <button id="infoClose" class="info-close" aria-label="Close information panel">
+        <span aria-hidden="true">×</span>
+      </button>
       <div class="info-content">
         <p class="lead">Classnoe Mesto is a <span class="vcut">creative collective.</span></p>
         <p class="roles">
@@ -45,7 +49,8 @@
           <span>writers</span>
         </p>
         <p class="founders">
-          Founded by <a href="#" rel="nofollow">Sasha</a> with Friends.
+          Founded by <em>Jony Ive</em><br>
+          with Marc Newson.
         </p>
       </div>
     </aside>

--- a/index.html
+++ b/index.html
@@ -13,9 +13,11 @@
 <body>
   <div id="app" class="app">
     <!-- Центральный слово-знак (без анимаций) -->
-    <h1 class="wordmark" aria-label="CLASSNOE MESTO">
-      <span aria-hidden="true">CLASSNOE&nbsp;MESTO</span>
-    </h1>
+    <div class="hero" id="hero">
+      <h1 class="wordmark" aria-label="CLASSNOE MESTO">
+        <span aria-hidden="true">CLASSNOE&nbsp;MESTO</span>
+      </h1>
+    </div>
 
     <!-- Бургер-кнопка (вместо "i") -->
     <button id="menuBtn" class="menu-btn" aria-expanded="false" aria-controls="infoPanel" aria-label="Open menu">

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 <body>
   <div id="app" class="app">
     <!-- Центральный слово-знак (без анимаций) -->
-    <h1 class="wordmark" aria-label="CLASSNOE MESTO,">
-      <span aria-hidden="true">CLASSNOE&nbsp;MESTO,</span>
+    <h1 class="wordmark" aria-label="CLASSNOE MESTO">
+      <span aria-hidden="true">CLASSNOE&nbsp;MESTO</span>
     </h1>
 
     <!-- Кнопка информации (правый верх) -->


### PR DESCRIPTION
## Summary
- rebuild the info panel markup to include a dedicated close button and updated founder text
- restyle the panel as a full-screen light overlay with centered serif typography and safe-area padding
- refresh the panel logic to support the new close button, Escape key, background click handling, and scroll locking

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d92e3224888331a866626aa32cb93c