### PR TITLE
Delay closing panel state cleanup until animations complete

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -158,10 +158,11 @@
     state = 'closing';
 
     root.classList.add('panel-closing');
-    root.classList.remove('panel-open');
 
     // параллельно: строки вверх + шторка снизу
     await Promise.all([ animateCloseLines(), animateWipeUp() ]);
+
+    root.classList.remove('panel-open');
 
     // скрываем панель только ПОСЛЕ анимаций
     infoPanel.setAttribute('aria-hidden','true');


### PR DESCRIPTION
## Summary
- wait for the closing animations to finish before removing the `panel-open` class so the reverse sequence stays visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e686ab5fec8331803e14a27e98d796