### PR TITLE
Stabilize info panel close sequencing

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -20,6 +20,14 @@
   /* управляемая длительность и задержка панели */
   --panel-duration: 1.6s;
   --panel-delay: .12s;
+  --panel-delay-active: 0s;
+
+  /* параметры покадрового появления/исчезновения строк */
+  --line-open-duration: 1.1s;
+  --line-close-duration: 1.1s;
+  --line-open-offset: 160ms;
+  --line-close-offset: 0ms;
+  --line-stagger: 95ms;
 
   /* высота видимой области, зададим из JS точно */
   --vh-usable: 100svh;
@@ -60,16 +68,24 @@ body{
 }
 
 .wordmark{
-  margin:0;
+  margin:0 auto;
   font-weight:800;
   letter-spacing:.01em;
   line-height:1.05;
-  font-size: clamp(28px, 10.5vw, 96px);
+  font-size: clamp(26px, 9vw, 88px);
   max-width: 92vw;
+  width: 100%;
+  display:flex;
+  justify-content:center;
+  text-align:center;
   transition:
     opacity 1.4s cubic-bezier(.16,1,.3,1),
     transform 1.4s cubic-bezier(.16,1,.3,1),
     filter 1.4s cubic-bezier(.16,1,.3,1);
+}
+.wordmark span{
+  display:block;
+  text-align:center;
 }
 .panel-opening .wordmark,
 .panel-open .wordmark{
@@ -100,28 +116,45 @@ body{
 .menu-btn.is-open .middle{ opacity:0; }
 .menu-btn.is-open .bottom{ transform: translateY(0) rotate(-45deg); }
 
-.info-panel{
-  position:fixed; inset:0;
-  background:var(--bg); color:var(--fg);
-  display:grid; place-items:center;
+:root.panel-opening{
+  --panel-delay-active: var(--panel-delay);
+}
+:root.panel-closing{
+  --panel-delay-active: 0s;
+}
+
+/* Отключаем клики, пока идёт анимация открытия/закрытия */
+.panel-opening .menu-btn,
+.panel-closing .menu-btn,
+.panel-opening .info-panel,
+.panel-closing .info-panel {
+  pointer-events: none;
+}
+
+.info-panel {
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  color: var(--fg);
+  display: grid;
+  place-items: center;
   padding:
     calc(max(24px, var(--padY)) + var(--safe-top-active))
     calc(max(24px, var(--padX)) + var(--safe-right-active))
     calc(max(28px, var(--padY)) + var(--safe-bottom-active))
     calc(max(24px, var(--padX)) + var(--safe-left-active));
   height: 100lvh;
-  overflow:auto;
+  overflow: auto;
 
-  opacity:0; transform: translateY(8%);
-  visibility:hidden;
-  transition:
-    opacity var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
-    transform var(--panel-duration) cubic-bezier(.16,1,.3,1) var(--panel-delay),
-    visibility 0s linear var(--panel-duration);
+  /* ВАЖНО: убрали все transition/opacity/transform */
+  opacity: 1;
+  visibility: visible;
+  transform: none;
+  transition: none;
 }
-.info-panel[aria-hidden="false"]{
-  opacity:1; transform: translateY(0);
-  visibility:visible; transition-delay: var(--panel-delay), var(--panel-delay), 0s;
+
+.info-panel[aria-hidden="true"] {
+  display: none; /* панель просто убирается после анимации из JS */
 }
 
 .info-fit{
@@ -134,6 +167,11 @@ body{
   margin:0 auto;
   text-align:center;
   line-height:1.28;
+}
+.lead,
+.roles span,
+.founders{
+  display:block;
 }
 .info-content .lead{
   font-size: clamp(24px, 6.6vw, 44px);
@@ -151,22 +189,51 @@ body{
   font-size: clamp(18px, 5vw, 26px);
 }
 
-@keyframes line-rise { from {opacity:0; transform: translateY(14px);} to {opacity:1; transform: translateY(0);} }
-@keyframes line-fall { from {opacity:1; transform: translateY(0);}     to {opacity:0; transform: translateY(14px);} }
-
-.info-panel[aria-hidden="false"] .line{
-  opacity:0;
-  animation: line-rise 1.1s cubic-bezier(.16,1,.3,1) forwards;
-  animation-delay: var(--delay, 0ms);
+@keyframes line-open {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-.panel-closing .line{
-  animation: line-fall 900ms cubic-bezier(.16,1,.3,1) forwards;
-  animation-delay: var(--delay, 0ms);
+@keyframes line-close {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-14px); }
+}
+
+.line {
+  will-change: opacity, transform;
+}
+
+.panel-opening .line {
+  opacity: 0;
+  animation: line-open 1100ms cubic-bezier(.16,1,.3,1) forwards;
+  animation-delay: var(--delay-open, 0ms);
+}
+
+.panel-closing .line {
+  opacity: 1;
+  animation: line-close 900ms cubic-bezier(.16,1,.3,1) forwards;
+  animation-delay: var(--delay-close, 0ms);
+}
+
+.panel-wipe{
+  position:absolute;
+  left:0; right:0; bottom:0;
+  height:0;
+  background:var(--bg);
+  pointer-events:none;
+  will-change:height;
+  z-index:5;
 }
 
 @media (max-width:380px){
   .wordmark{ font-size: clamp(26px, 9.2vw, 70px); }
+}
+
+@media (max-width:480px){
+  .info-content{ line-height:1.22; }
+  .info-content .lead{ font-size: clamp(22px, 7.4vw, 34px); margin-bottom: 22px; }
+  .info-content .roles{ font-size: clamp(18px, 6.2vw, 24px); gap: 8px; margin-bottom: 26px; }
+  .info-content .founders{ font-size: clamp(16px, 5.8vw, 22px); }
 }
 
 @media (prefers-reduced-motion: reduce){

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,166 +3,163 @@
   const root      = document.documentElement;
   const menuBtn   = document.getElementById('menuBtn');
   const infoPanel = document.getElementById('infoPanel');
-  const infoFit   = infoPanel.querySelector('.info-fit');
   const infoCont  = infoPanel.querySelector('.info-content');
+  const infoFit   = infoPanel.querySelector('.info-fit') || infoPanel;
+  const wipe      = infoPanel.querySelector('.panel-wipe');
 
-  let showTimer = null;
-  let finalizeTimer = null;
-  let closeTimer = null;
+  const OPEN_BASE = 160, OPEN_STEP = 95, OPEN_DUR = 1100;
+  const CLOSE_BASE = 0, CLOSE_STEP = 95, CLOSE_DUR = 900;
+  const easing = 'cubic-bezier(.16,1,.3,1)';
 
-  function prepareLines(){
-    const nodes = [];
-    const lead = infoCont.querySelector('.lead');
-    if (lead) nodes.push(lead);
+  let state = 'closed'; // closed | opening | open | closing
 
-    infoCont.querySelectorAll('.roles span').forEach((node) => nodes.push(node));
-
-    const founders = infoCont.querySelector('.founders');
-    if (founders) nodes.push(founders);
-
-    nodes.forEach((el, index) => {
-      el.classList.add('line');
-      el.style.setProperty('--delay', `${160 + index * 95}ms`);
-    });
+  function collectLines() {
+    const lines = [];
+    const lead = infoCont.querySelector('.lead'); if (lead) lines.push(lead);
+    infoCont.querySelectorAll('.roles span').forEach(n => lines.push(n));
+    const founders = infoCont.querySelector('.founders'); if (founders) lines.push(founders);
+    return lines;
   }
 
+  // Автофит текста в панель
   function fitInfo(){
-    const panelStyles = getComputedStyle(infoPanel);
-    const padTop = parseFloat(panelStyles.paddingTop) || 0;
-    const padBottom = parseFloat(panelStyles.paddingBottom) || 0;
-    const available = infoPanel.clientHeight - padTop - padBottom;
+    const s = getComputedStyle(infoPanel);
+    const padTop = parseFloat(s.paddingTop);
+    const padBottom = parseFloat(s.paddingBottom);
+    const avail = infoPanel.clientHeight - padTop - padBottom;
 
-    infoFit.style.setProperty('--panel-scale', '1');
     infoFit.style.transform = 'scale(1)';
-    root.style.setProperty('--panel-scale', '1');
+    const need = infoFit.scrollHeight;
 
-    const needed = infoFit.scrollHeight;
     let scale = 1;
-    if (needed > available && available > 0){
-      scale = Math.max(0.75, available / needed);
-    }
-
-    root.style.setProperty('--panel-scale', `${scale}`);
+    if (need > avail) scale = Math.max(0.75, avail / need);
     infoFit.style.transform = `scale(${scale})`;
   }
 
-  function clearOpenTimers(){
-    if (showTimer){
-      clearTimeout(showTimer);
-      showTimer = null;
-    }
-    if (finalizeTimer){
-      clearTimeout(finalizeTimer);
-      finalizeTimer = null;
-    }
+  async function animateOpenLines(lines) {
+    lines.forEach((el, i) => {
+      el.style.opacity = '0';
+      el.animate(
+        [
+          { opacity: 0, transform: 'translateY(14px)' },
+          { opacity: 1, transform: 'translateY(0)' }
+        ],
+        {
+          duration: OPEN_DUR,
+          delay: OPEN_BASE + i * OPEN_STEP,
+          easing,
+          fill: 'forwards'
+        }
+      );
+    });
+    const lastDelay = OPEN_BASE + (lines.length - 1) * OPEN_STEP;
+    return new Promise(res => setTimeout(res, lastDelay + OPEN_DUR));
   }
 
-  function clearCloseTimer(){
-    if (closeTimer){
-      clearTimeout(closeTimer);
-      closeTimer = null;
-    }
+  async function animateCloseLines(lines) {
+    const n = lines.length;
+    lines.forEach((el, i) => {
+      const rev = n - 1 - i;
+      el.animate(
+        [
+          { opacity: 1, transform: 'translateY(0)' },
+          { opacity: 0, transform: 'translateY(-14px)' }
+        ],
+        {
+          duration: CLOSE_DUR,
+          delay: CLOSE_BASE + rev * CLOSE_STEP,
+          easing,
+          fill: 'forwards'
+        }
+      );
+    });
+    const lastDelay = CLOSE_BASE + (n - 1) * CLOSE_STEP;
+    return new Promise(res => setTimeout(res, lastDelay + CLOSE_DUR));
   }
 
-  function openPanel() {
-    if (!menuBtn || menuBtn.getAttribute('aria-expanded') === 'true') return;
+  function animateWipeUp() {
+    if (!wipe) return Promise.resolve();
+    wipe.style.height = '0px';
+    wipe.offsetHeight; // рефлоу
+    const anim = wipe.animate(
+      [{ height: '0px' }, { height: '100%' }],
+      { duration: CLOSE_DUR, easing, fill: 'forwards' }
+    );
+    return anim.finished.catch(() => {});
+  }
 
-    clearCloseTimer();
+  function resetWipe() {
+    if (!wipe) return;
+    wipe.style.height = '0px';
+  }
 
+  async function openPanel() {
+    if (state !== 'closed') return;
+    state = 'opening';
     if (window.__freezeSafeAreas) window.__freezeSafeAreas();
 
-    root.classList.remove('panel-closing');
     root.classList.add('panel-opening');
     menuBtn.classList.add('is-open');
     menuBtn.setAttribute('aria-expanded','true');
 
-    showTimer = window.setTimeout(() => {
-      prepareLines();
-      infoPanel.setAttribute('aria-hidden','false');
-      requestAnimationFrame(() => {
-        fitInfo();
-      });
-    }, 120);
+    // показываем панель
+    infoPanel.setAttribute('aria-hidden','false');
+    requestAnimationFrame(fitInfo);
+
+    const lines = collectLines();
+    await animateOpenLines(lines);
+
+    root.classList.remove('panel-opening');
+    root.classList.add('panel-open');
 
     document.documentElement.style.overflow = 'hidden';
     document.body.style.overflow = 'hidden';
 
-    finalizeTimer = window.setTimeout(() => {
-      root.classList.remove('panel-opening');
-      root.classList.add('panel-open');
-      finalizeTimer = null;
-    }, 1600);
+    state = 'open';
   }
 
-  function closePanel() {
-    if (!menuBtn) return;
+  async function closePanel() {
+    if (state !== 'open') return;
+    state = 'closing';
 
-    clearOpenTimers();
-    clearCloseTimer();
-
-    const isOpening = root.classList.contains('panel-opening');
-    const isOpen = root.classList.contains('panel-open');
-    if (!isOpening && !isOpen && menuBtn.getAttribute('aria-expanded') !== 'true') {
-      return;
-    }
-
-    root.classList.remove('panel-opening');
     root.classList.add('panel-closing');
     root.classList.remove('panel-open');
 
-    closeTimer = window.setTimeout(() => {
-      infoPanel.setAttribute('aria-hidden','true');
+    const lines = collectLines();
+    await Promise.all([ animateCloseLines(lines), animateWipeUp() ]);
 
-      menuBtn.classList.remove('is-open');
-      menuBtn.setAttribute('aria-expanded','false');
+    // только теперь скрываем панель
+    infoPanel.setAttribute('aria-hidden','true');
+    resetWipe();
 
-      document.documentElement.style.overflow = '';
-      document.body.style.overflow = '';
+    menuBtn.classList.remove('is-open');
+    menuBtn.setAttribute('aria-expanded','false');
 
-      root.classList.remove('panel-closing');
+    document.documentElement.style.overflow = '';
+    document.body.style.overflow = '';
 
-      if (window.__unfreezeSafeAreas) window.__unfreezeSafeAreas();
-      closeTimer = null;
-    }, 900);
+    root.classList.remove('panel-closing');
+    if (window.__unfreezeSafeAreas) window.__unfreezeSafeAreas();
+
+    state = 'closed';
   }
 
   function togglePanel(){
-    if (!menuBtn) return;
-    const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
-    expanded ? closePanel() : openPanel();
+    if (state === 'closed') openPanel();
+    else if (state === 'open') closePanel();
   }
 
-  if (menuBtn){
-    menuBtn.addEventListener('click', togglePanel);
-  }
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') closePanel();
+  menuBtn.addEventListener('click', togglePanel);
+  document.addEventListener('keydown', e => { if (e.key === 'Escape') closePanel(); });
+  infoPanel.addEventListener('click', (e) => {
+    if (e.target === infoPanel) closePanel();
   });
 
-  infoPanel.addEventListener('click', (event) => {
-    const content = infoCont;
-    if (event.target === event.currentTarget || !content.contains(event.target)) {
-      closePanel();
-    }
-  });
-
-  window.addEventListener('resize', () => {
-    if (infoPanel.getAttribute('aria-hidden') === 'false') {
-      fitInfo();
-    }
-  });
+  const fitIfOpen = () => { if (state === 'open') fitInfo(); };
+  window.addEventListener('resize', fitIfOpen);
   if (window.visualViewport){
-    window.visualViewport.addEventListener('resize', () => {
-      if (infoPanel.getAttribute('aria-hidden') === 'false') {
-        fitInfo();
-      }
-    }, { passive: true });
+    window.visualViewport.addEventListener('resize', fitIfOpen, { passive:true });
   }
 
   infoPanel.setAttribute('aria-hidden','true');
-  if (menuBtn){
-    menuBtn.setAttribute('aria-expanded','false');
-  }
-  root.classList.remove('panel-open','panel-opening','panel-closing');
 })();

--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
           </p>
         </div>
       </div>
+      <div class="panel-wipe" aria-hidden="true"></div>
     </aside>
   </div>
 


### PR DESCRIPTION
## Summary
- remove conflicting info panel transitions so visibility is JS-controlled
- await both the staggered line cascade and wipe animation before hiding the panel

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9495d14d48331b0a63813f0866cbb